### PR TITLE
Add AOP Around Advice and Validate Order of Multiple Aspects

### DIFF
--- a/spring-02-aop/src/main/java/linzi/ssm/spring/aop/aspect/AroundAspect.java
+++ b/spring-02-aop/src/main/java/linzi/ssm/spring/aop/aspect/AroundAspect.java
@@ -1,0 +1,44 @@
+package linzi.ssm.spring.aop.aspect;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Pointcut;
+import org.junit.jupiter.api.Order;
+import org.springframework.stereotype.Component;
+
+@Aspect
+@Component
+@Order(1)
+public class AroundAspect {
+
+    @Pointcut("execution(int *(int, int))")
+    public void pointCut() {};
+
+    /**
+     * 环绕通知有固定写法
+     *  Object: 返回值
+     *  ProceedingJoinPoint: 可以继续推进的切点.
+     */
+    @Around(value = "pointCut()")
+    public Object aroundAdvise(ProceedingJoinPoint joinPoint) throws Throwable {
+        Object result = null;
+        Object[] args = joinPoint.getArgs();// 获取目标方法的参数.
+
+        // 环绕通知 - 前置.
+        System.out.println("1-@Before.");
+
+        // 接受传入参数的 proceed, 实现修改目标方法执行的参数.
+        try{
+            result = joinPoint.proceed(args);// 执行目标方法. 类似反射里的 method.invoke()
+            System.out.println("1-@AfterReturning.");
+        } catch (Throwable throwable) {
+            System.out.println("1-@AfterThrowing");
+        } finally {
+            System.out.println("1-@After");
+        }
+
+        return result;
+    }
+
+}

--- a/spring-02-aop/src/main/java/linzi/ssm/spring/aop/aspect/AroundAspect02.java
+++ b/spring-02-aop/src/main/java/linzi/ssm/spring/aop/aspect/AroundAspect02.java
@@ -1,0 +1,45 @@
+package linzi.ssm.spring.aop.aspect;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Pointcut;
+import org.junit.jupiter.api.Order;
+import org.springframework.stereotype.Component;
+
+@Aspect
+@Component
+@Order(2)
+public class AroundAspect02 {
+
+    @Pointcut("execution(int *(int, int))")
+    public void pointCut() {};
+
+    /**
+     * 环绕通知有固定写法
+     *  Object: 返回值
+     *  ProceedingJoinPoint: 可以继续推进的切点.
+     */
+    @Around(value = "pointCut()")
+    public Object aroundAdvise(ProceedingJoinPoint joinPoint) throws Throwable {
+        Object result = null;
+        Object[] args = joinPoint.getArgs();// 获取目标方法的参数.
+
+        // 环绕通知 - 前置.
+        System.out.println("2-@Before.");
+
+        // 接受传入参数的 proceed, 实现修改目标方法执行的参数.
+        try{
+            result = joinPoint.proceed(args);// 执行目标方法. 类似反射里的 method.invoke()
+            System.out.println("2-@AfterReturning.");
+        } catch (Throwable throwable) {
+            System.out.println("2-@AfterThrowing");
+            throw throwable;
+        } finally {
+            System.out.println("2-@After");
+        }
+
+        return result;
+    }
+
+}

--- a/spring-02-aop/src/main/java/linzi/ssm/spring/aop/aspect/LogAspect.java
+++ b/spring-02-aop/src/main/java/linzi/ssm/spring/aop/aspect/LogAspect.java
@@ -10,7 +10,7 @@ import org.springframework.stereotype.Component;
 import java.util.Arrays;
 
 @Order(1)// 数字越小, 优先级越高, 默认是按照类名字母顺序排序.
-@Component
+//@Component
 @Aspect// 表明这是一个 Spring 的切面类.
 public class LogAspect {
 
@@ -27,6 +27,8 @@ public class LogAspect {
      *  @AfterThrowing, 方法抛出异常时,
      *  @After, 方法执行之后.
      *
+     *  @Around, 环绕通知, 可以控制目标方法是否执行, 修改目标方法执行的结果.
+     *
      * 何地?
      *  切入点表达式:
      *      execution(方法的全签名)
@@ -36,7 +38,6 @@ public class LogAspect {
      *              * 任意字符.
      *              .. 多个参数, 任意类型.
      *              * *(..) 最省略, 最通配.
-     *
      *  通知方法的执行顺序:
      *      1. 正常链路: @Before -> 目标方法 -> @AfterReturn -> @After.
      *      2. 异常链路: @Before -> 目标方法 -> @AfterThrowing -> @After.
@@ -48,23 +49,23 @@ public class LogAspect {
         MethodSignature signature = (MethodSignature) joinPoint.getSignature(); // 拿到方法的全签名.
         String methodName = signature.getName();// 获取方法名.
         Object[] args = joinPoint.getArgs();// 目标方法传来的参数的值.
-        System.out.println("[切面-日志] logStart... "+ methodName + Arrays.asList(args));
+        System.out.println("[切面-日志1] logStart... "+ methodName + Arrays.asList(args));
     }
 
     @After(value = "pointCut()")
     public void logEnd(JoinPoint joinPoint) {
-        System.out.println("[切面-日志] logEnd..." + joinPoint.getSignature().getName());
+        System.out.println("[切面-日志1] logEnd..." + joinPoint.getSignature().getName());
     }
 
     @AfterReturning(value = "pointCut()", returning = "result")
     public void logReturn(JoinPoint joinPoint, Object result) {
-        System.out.println("[切面-日志] logReturn..." + result);
+        System.out.println("[切面-日志1] logReturn..." + result);
     }
 
     @AfterThrowing(value = "pointCut()", throwing = "e")
     public void logException(JoinPoint joinPoint, Throwable e) {
         // 如果指明了 e 是某一种异常, 则不一定会除触发这个切面方法.
-        System.out.println("[切面-日志] logException..." + joinPoint.getSignature().getName() + e.getMessage());
+        System.out.println("[切面-日志1] logException..." + joinPoint.getSignature().getName() + e.getMessage());
     }
 
 }

--- a/spring-02-aop/src/main/java/linzi/ssm/spring/aop/aspect/LogAspect02.java
+++ b/spring-02-aop/src/main/java/linzi/ssm/spring/aop/aspect/LogAspect02.java
@@ -1,0 +1,51 @@
+package linzi.ssm.spring.aop.aspect;
+
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.*;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.junit.jupiter.api.Order;
+import org.springframework.stereotype.Component;
+
+import java.util.Arrays;
+
+@Order(2)// 数字越小, 优先级越高, 默认是按照类名字母顺序排序.
+//@Component
+@Aspect// 表明这是一个 Spring 的切面类.
+public class LogAspect02 {
+
+    @Pointcut("execution(int *(int, int))")
+    public void pointCut() {
+        // 空方法, 目的是抽取切入点表达式.
+    };
+
+    @Before(value = "pointCut()")
+    public void logStart(JoinPoint joinPoint) {
+        MethodSignature signature = (MethodSignature) joinPoint.getSignature(); // 拿到方法的全签名.
+        String methodName = signature.getName();// 获取方法名.
+        Object[] args = joinPoint.getArgs();// 目标方法传来的参数的值.
+        System.out.println("[切面-日志2] logStart... "+ methodName + Arrays.asList(args));
+    }
+
+    @After(value = "pointCut()")
+    public void logEnd(JoinPoint joinPoint) {
+        System.out.println("[切面-日志2] logEnd..." + joinPoint.getSignature().getName());
+    }
+
+    @AfterReturning(value = "pointCut()", returning = "result")
+    public void logReturn(JoinPoint joinPoint, Object result) {
+        System.out.println("[切面-日志2] logReturn..." + result);
+    }
+
+    @AfterThrowing(value = "pointCut()", throwing = "e")
+    public void logException(JoinPoint joinPoint, Throwable e) {
+        // 如果指明了 e 是某一种异常, 则不一定会除触发这个切面方法.
+        try {
+            if (e != null) {
+                System.out.println("[切面-日志2] logException..." + joinPoint.getSignature().getName() + e.getMessage());
+            }
+        } catch (Exception ex) {
+            System.out.println("抛出异常!");
+        }
+    }
+
+}

--- a/spring-02-aop/src/test/java/linzi/ssm/spring/aop/Spring02AopApplicationTests.java
+++ b/spring-02-aop/src/test/java/linzi/ssm/spring/aop/Spring02AopApplicationTests.java
@@ -90,8 +90,7 @@ class Spring02AopApplicationTests {
      */
     @Test
     void testAOP() {
-        mathCalculator.add(1, 2);
-        mathCalculator.divide(2, 0);
+        mathCalculator.divide(1, 0);
     }
 
 }


### PR DESCRIPTION
- Implemented around advice in AOP to manage method execution flow and additional logic.
- Verified the execution order of multiple aspects using the @Order annotation.
- Ensured the correct application of before, after, and around advice methods in the LogAspect and other aspect classes.
- Conducted tests to validate the combined behavior and order of different aspect notifications.