### PR TITLE
Added RequestMapping limitations in SpringMVC Controller

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,7 @@
         <module>spring-01-ioc</module>
         <module>spring-02-aop</module>
         <module>spring-03-transaction</module>
+        <module>springmvc-01-helloworld</module>
     </modules>
 
 </project>

--- a/springmvc-01-helloworld/pom.xml
+++ b/springmvc-01-helloworld/pom.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.springframework.boot</groupId>
+		<artifactId>spring-boot-starter-parent</artifactId>
+		<version>3.3.5</version>
+		<relativePath/> <!-- lookup parent from repository -->
+	</parent>
+	<groupId>linzi.ssm</groupId>
+	<artifactId>springmvc-01-helloworld</artifactId>
+	<version>0.0.1-SNAPSHOT</version>
+	<name>springmvc-01-helloworld</name>
+	<description>springmvc-01-helloworld</description>
+	<url/>
+	<licenses>
+		<license/>
+	</licenses>
+	<developers>
+		<developer/>
+	</developers>
+	<scm>
+		<connection/>
+		<developerConnection/>
+		<tag/>
+		<url/>
+	</scm>
+	<properties>
+		<java.version>21</java.version>
+	</properties>
+	<dependencies>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-web</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.projectlombok</groupId>
+			<artifactId>lombok</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-maven-plugin</artifactId>
+				<configuration>
+					<excludes>
+						<exclude>
+							<groupId>org.projectlombok</groupId>
+							<artifactId>lombok</artifactId>
+						</exclude>
+					</excludes>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/springmvc-01-helloworld/src/main/java/linzi/ssm/springmvc/Springmvc01HelloWorldApplication.java
+++ b/springmvc-01-helloworld/src/main/java/linzi/ssm/springmvc/Springmvc01HelloWorldApplication.java
@@ -1,0 +1,13 @@
+package linzi.ssm.springmvc;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class Springmvc01HelloWorldApplication {
+
+	public static void main(String[] args) {
+		SpringApplication.run(Springmvc01HelloWorldApplication.class, args);
+	}
+
+}

--- a/springmvc-01-helloworld/src/main/java/linzi/ssm/springmvc/controller/HelloWorldController.java
+++ b/springmvc-01-helloworld/src/main/java/linzi/ssm/springmvc/controller/HelloWorldController.java
@@ -1,0 +1,23 @@
+package linzi.ssm.springmvc.controller;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+@Controller
+@ResponseBody // 单例模式, 每次请求都执行一次目标方法.// 处理请求的控制器
+public class HelloWorldController {
+
+    /**
+     * SpringBoot所做的工作:
+     * 不用整合 tomcat.
+     * 不实现 servlet 接口.
+     * 自动解决乱码问题.
+     */
+    @RequestMapping("/hell?")
+    public String helloWorld() {
+        System.out.println("执行了一次目标方法.");
+        return "Hello, SpringMVC!"; // 默认返回值是一个页面, 需要注解 @ResponseBody
+    }
+
+}

--- a/springmvc-01-helloworld/src/main/java/linzi/ssm/springmvc/controller/RequestMappingLimitController.java
+++ b/springmvc-01-helloworld/src/main/java/linzi/ssm/springmvc/controller/RequestMappingLimitController.java
@@ -1,0 +1,74 @@
+package linzi.ssm.springmvc.controller;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController // 一个顶俩
+public class RequestMappingLimitController {
+
+    /**
+     * 限定请求方式.
+     * GET, HEAD, POST, PUT, PATCH, DELETE, OPTIONS, TRACE;
+     */
+    @RequestMapping(value = "/limit-method",
+            method = {RequestMethod.POST, RequestMethod.GET})
+    public String limitMethod() {
+        // 浏览器表单页面只能发送 GET 请求, 会报错.
+        return "POST ONLY!";
+    }
+
+    /**
+     * 限定请求参数.
+     * 必须有参数 username, age. 且 age 的值一定为 18.
+     */
+    @RequestMapping(value = "/limit-params",
+            params = {"username", "age=18", "gender!=male"})
+    public String limitParams() {
+        return "VALID PARAMS ONLY!";
+    }
+
+    /**
+     * 限定请求头.
+     */
+    @RequestMapping(value = "/limit-headers",
+            headers = {"valid-headers"})
+    public String limitHeaders() {
+        return "VALID HEADERS ONLY!";
+    }
+
+    /**
+     * 请求时必须携带 JSON 格式的数据.
+     * application/json - 传输JSON格式的数据
+     * application/xml - 传输XML格式的数据
+     * multipart/form-data - 传输表单文件数据
+     * application/x-www-form-urlencoded - 传输普通表单数据
+     * application/octet-stream - 传输二进制数据流
+     * text/plain - 传输纯文本数据
+     * text/html - 传输HTML文本数据
+     * application/pdf - 传输PDF文件
+     */
+    @RequestMapping(value = "/limit-consumes",
+            consumes = "application/json")
+    public String limitConsumes() {
+        return "MUST BE JSON STRING!";
+    }
+
+    /**
+     * 规定服务器回传的数据类型.
+     * application/json - 生成JSON格式的数据
+     * application/xml - 生成XML格式的数据
+     * multipart/form-data - 生成表单文件数据
+     * application/x-www-form-urlencoded - 生成普通表单数据
+     * application/octet-stream - 生成二进制数据流
+     * text/plain - 生成纯文本数据
+     * text/html - 生成HTML文本数据
+     * application/pdf - 生成PDF文件
+     */
+    @RequestMapping(value = "/limit-produces",
+            produces = "text/html")
+    public String limitProduces() {
+        return "<h1>HTML</h1>";
+    }
+
+}

--- a/springmvc-01-helloworld/src/main/resources/application.properties
+++ b/springmvc-01-helloworld/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+spring.application.name=springmvc-01-helloworld

--- a/springmvc-01-helloworld/src/test/java/linzi/ssm/springmvc/Springmvc01HelloworldApplicationTests.java
+++ b/springmvc-01-helloworld/src/test/java/linzi/ssm/springmvc/Springmvc01HelloworldApplicationTests.java
@@ -1,0 +1,13 @@
+package linzi.ssm.springmvc;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class Springmvc01HelloworldApplicationTests {
+
+	@Test
+	void contextLoads() {
+	}
+
+}


### PR DESCRIPTION
- Limited methods to POST and GET.
- Restricted params to include 'username', 'age=18', and 'gender!=male'.
- Added header restrictions with 'valid-headers'.
- Set consumes to application/json.
- Set produces to text/html.